### PR TITLE
added option to set codec

### DIFF
--- a/projects/angular-agora-rtc/src/lib/angular-agora-rtc.service.ts
+++ b/projects/angular-agora-rtc/src/lib/angular-agora-rtc.service.ts
@@ -41,8 +41,8 @@ export class AngularAgoraRtcService {
     });
   }
 
-  createClient(mode: string = 'interop') {
-     this.client = AgoraRTC.createClient({ mode: mode });
+  createClient(mode: string = 'interop', codec: string = 'vp8') {
+     this.client = AgoraRTC.createClient({ mode: mode, codec: codec });
      this.client.init(this.config.AppID);
   }
 


### PR DESCRIPTION
Exposed option to set `codec` within the `createClient` function. Set default to `vp8`, as `h264` is not supported on mobile.